### PR TITLE
ft: Add API endpoints for CRUD operations on categories

### DIFF
--- a/conduit/apps/articles/renderers.py
+++ b/conduit/apps/articles/renderers.py
@@ -11,3 +11,9 @@ class CommentJSONRenderer(ConduitJSONRenderer):
     object_label = 'comment'
     pagination_object_label = 'comments'
     pagination_count_label = 'commentsCount'
+
+
+class CategoryJSONRenderer(ConduitJSONRenderer):
+    object_label = 'category'
+    pagination_object_label = 'categories'
+    pagination_count_label = 'categoriesCount'

--- a/conduit/apps/articles/serializers.py
+++ b/conduit/apps/articles/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from conduit.apps.profiles.serializers import ProfileSerializer
 
-from .models import Article, Comment, Tag
+from .models import Article, Category, Comment, Tag
 from .relations import TagRelatedField
 
 
@@ -112,3 +112,15 @@ class TagSerializer(serializers.ModelSerializer):
 
     def to_representation(self, obj):
         return obj.tag
+
+
+class CategorySerializer(serializers.ModelSerializer):
+    parent = serializers.CharField(source='parent_category')
+    name = serializers.CharField(source='article_category')
+
+    class Meta:
+        model = Category
+        fields = ('name', 'parent',)
+
+    def to_representation(self, obj):
+        return obj.name

--- a/conduit/apps/articles/urls.py
+++ b/conduit/apps/articles/urls.py
@@ -4,11 +4,13 @@ from rest_framework.routers import DefaultRouter
 
 from .views import (
     ArticleViewSet, ArticlesFavoriteAPIView, ArticlesFeedAPIView,
-    CommentsListCreateAPIView, CommentsDestroyAPIView, TagListAPIView
+    CategoryViewSet, CommentsListCreateAPIView, CommentsDestroyAPIView,
+    TagListAPIView
 )
 
 router = DefaultRouter(trailing_slash=False)
 router.register(r'articles', ArticleViewSet)
+router.register(r'categories', CategoryViewSet)
 
 urlpatterns = [
     url(r'^', include(router.urls)),
@@ -18,10 +20,11 @@ urlpatterns = [
     url(r'^articles/(?P<article_slug>[-\w]+)/favorite/?$',
         ArticlesFavoriteAPIView.as_view()),
 
-    url(r'^articles/(?P<article_slug>[-\w]+)/comments/?$', 
+    url(r'^articles/(?P<article_slug>[-\w]+)/comments/?$',
         CommentsListCreateAPIView.as_view()),
 
-    url(r'^articles/(?P<article_slug>[-\w]+)/comments/(?P<comment_pk>[\d]+)/?$',
+    url(
+        r'^articles/(?P<article_slug>[-\w]+)/comments/(?P<comment_pk>[\d]+)/?$',
         CommentsDestroyAPIView.as_view()),
 
     url(r'^tags/?$', TagListAPIView.as_view()),


### PR DESCRIPTION
Added the API endpoints for CRUD operations on categories as well as relevant setup in the `articles.renderers`, `articles.serializers` and `articles.urls` modules